### PR TITLE
add ParseDecimal()

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,33 @@
+package decimal128
+
+import (
+	"testing"
+)
+
+func BenchmarkParse_short(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Parse("333333333.333333")
+	}
+}
+
+func BenchmarkParse_long(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Parse("1234567890.0123456789")
+	}
+}
+
+func BenchmarkParseDecimal_short(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseDecimal("333333333.333333")
+	}
+}
+
+func BenchmarkParseDecimal_long(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseDecimal("1234567890.0123456789")
+	}
+}

--- a/compare.go
+++ b/compare.go
@@ -3,9 +3,9 @@ package decimal128
 // CmpResult represents the result from comparing two Decimals. When the values
 // being compared aren't NaNs, the integer value of the CmpResult will be:
 //
-//   -1 if lhs < rhs
-//    0 if lhs == rhs
-//   +1 if lhs > rhs
+//	-1 if lhs < rhs
+//	 0 if lhs == rhs
+//	+1 if lhs > rhs
 //
 // The Equal, Greater, and Less methods can also be used to determine the
 // result. If either value is a NaN, then these methods will still behave

--- a/decimal.go
+++ b/decimal.go
@@ -127,9 +127,9 @@ func (d Decimal) Neg() Decimal {
 
 // Sign returns:
 //
-//   -1 if d <   0
-//    0 if d is ±0
-//   +1 if d >   0
+//	-1 if d <   0
+//	 0 if d is ±0
+//	+1 if d >   0
 //
 // It panics if d is NaN.
 func (d Decimal) Sign() int {

--- a/scan_test.go
+++ b/scan_test.go
@@ -64,6 +64,20 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseDecimal(t *testing.T) {
+	t.Parallel()
+
+	for val, num := range textValues {
+		if num.IsNaN() || num.IsInf(0) {
+			continue
+		}
+		res, err := ParseDecimal(fmt.Sprintf("%.12287f", num))
+		if !(res.Equal(num) || res.IsNaN() && num.IsNaN()) || res.Signbit() != num.Signbit() || err != nil {
+			t.Errorf("Parse(%s) = (%v, %v), want (%v, <nil>)", val, res, err, num)
+		}
+	}
+}
+
 func FuzzParse(f *testing.F) {
 	f.Add("123_456.789e10")
 	f.Add("+Inf")


### PR DESCRIPTION
I am very pleased with your package. The reason for this PR is to request an optimization for Parse() for short strings like "±nnnn.mmmm" (see benchmarks), which are very commonly used in fintech today. I did not find another way to contact you.