### PR TITLE
format: Reduce allocations made during formatting

### DIFF
--- a/format.go
+++ b/format.go
@@ -355,6 +355,15 @@ type digits struct {
 func (d *digits) fmtE(prec, pad int, forceDP, printSign, padSign, padExp, padRight, padZero bool, e byte) []byte {
 	var buf []byte
 
+	// Attempt to pre-size buffer to avoid multiple allocations. Currently,
+	// this might overshoot the actual needed size. Calculation is:
+	// sign + decimal separator + exponent + signficant digits + padding.
+	sizeHint := 1 + 1 + 5 + d.ndig
+	if pad > sizeHint {
+		sizeHint = pad
+	}
+	buf = make([]byte, 0, sizeHint)
+
 	if d.neg {
 		buf = append(buf, '-')
 	} else if printSign {
@@ -419,6 +428,15 @@ func (d *digits) fmtE(prec, pad int, forceDP, printSign, padSign, padExp, padRig
 
 func (d *digits) fmtF(prec, pad int, forceDP, printSign, padSign, padRight, padZero bool) []byte {
 	var buf []byte
+
+	// Attempt to pre-size buffer to avoid multiple allocations. Currently,
+	// this might overshoot the actual needed size. Calculation is:
+	// sign + decimal separator + signficant digits + padding.
+	sizeHint := 1 + 1 + d.ndig
+	if pad > sizeHint {
+		sizeHint = pad
+	}
+	buf = make([]byte, 0, sizeHint)
 
 	if d.neg {
 		buf = append(buf, '-')

--- a/format.go
+++ b/format.go
@@ -413,36 +413,7 @@ func (d *digits) fmtE(prec, pad int, forceDP, printSign, padSign, padExp, padRig
 		buf = append(buf, '0'+byte(exp/1000), '0'+byte(exp/100%10), '0'+byte(exp/10%10), '0'+byte(exp%10))
 	}
 
-	if p := pad - len(buf); p > 0 {
-		padChar := byte(' ')
-		if padZero {
-			padChar = byte('0')
-		}
-
-		if padRight {
-			for i := 0; i < p; i++ {
-				buf = append(buf, padChar)
-			}
-		} else {
-			tmp := make([]byte, pad)
-			i := 0
-
-			if padZero && (d.neg || printSign || padSign) {
-				tmp[0] = buf[0]
-				buf = buf[1:]
-				i = 1
-				p++
-			}
-
-			for ; i < p; i++ {
-				tmp[i] = padChar
-			}
-
-			copy(tmp[p:], buf)
-			buf = tmp
-		}
-	}
-
+	buf = d.pad(buf, pad, printSign, padSign, padRight, padZero)
 	return buf
 }
 
@@ -499,34 +470,44 @@ func (d *digits) fmtF(prec, pad int, forceDP, printSign, padSign, padRight, padZ
 		buf = append(buf, '.')
 	}
 
-	if p := pad - len(buf); p > 0 {
-		padChar := byte(' ')
-		if padZero {
-			padChar = byte('0')
+	buf = d.pad(buf, pad, printSign, padSign, padRight, padZero)
+	return buf
+}
+
+// pad adds padding to the passed buf.
+func (d *digits) pad(buf []byte, pad int, printSign, padSign, padRight, padZero bool) []byte {
+	p := pad - len(buf)
+	if p <= 0 {
+		// No need for padding.
+		return buf
+	}
+
+	padChar := byte(' ')
+	if padZero {
+		padChar = byte('0')
+	}
+
+	if padRight {
+		for i := 0; i < p; i++ {
+			buf = append(buf, padChar)
+		}
+	} else {
+		tmp := make([]byte, pad)
+		i := 0
+
+		if padZero && (d.neg || printSign || padSign) {
+			tmp[0] = buf[0]
+			buf = buf[1:]
+			i = 1
+			p++
 		}
 
-		if padRight {
-			for i := 0; i < p; i++ {
-				buf = append(buf, padChar)
-			}
-		} else {
-			tmp := make([]byte, pad)
-			i := 0
-
-			if padZero && (d.neg || printSign || padSign) {
-				tmp[0] = buf[0]
-				buf = buf[1:]
-				i = 1
-				p++
-			}
-
-			for ; i < p; i++ {
-				tmp[i] = padChar
-			}
-
-			copy(tmp[p:], buf)
-			buf = tmp
+		for ; i < p; i++ {
+			tmp[i] = padChar
 		}
+
+		copy(tmp[p:], buf)
+		buf = tmp
 	}
 
 	return buf

--- a/format.go
+++ b/format.go
@@ -60,7 +60,8 @@ func (d Decimal) Format(f fmt.State, verb rune) {
 		return
 	}
 
-	digs := d.digits()
+	var digs digits
+	d.digits(&digs)
 	prec, hasPrec := f.Precision()
 
 	switch verb {
@@ -196,7 +197,8 @@ func (d Decimal) MarshalText() ([]byte, error) {
 		return d.fmtSpecial(0, false, false, false, true), nil
 	}
 
-	digs := d.digits()
+	var digs digits
+	d.digits(&digs)
 
 	prec := 0
 	if digs.ndig != 0 {
@@ -223,7 +225,8 @@ func (d Decimal) String() string {
 		return string(d.fmtSpecial(0, false, false, false, false))
 	}
 
-	digs := d.digits()
+	var digs digits
+	d.digits(&digs)
 
 	prec := 0
 	if digs.ndig != 0 {
@@ -244,10 +247,9 @@ func (d Decimal) String() string {
 	return string(digs.fmtF(prec, 0, false, false, false, false, false))
 }
 
-func (d Decimal) digits() *digits {
-	digs := &digits{
-		neg: d.Signbit(),
-	}
+func (d Decimal) digits(digs *digits) {
+	*digs = digits{}
+	digs.neg = d.Signbit()
 
 	sig, exp := d.decompose()
 
@@ -288,8 +290,6 @@ func (d Decimal) digits() *digits {
 
 		digs.ndig = n
 	}
-
-	return digs
 }
 
 func (d Decimal) fmtSpecial(pad int, printSign, padSign, padRight, copyBuf bool) []byte {

--- a/format.go
+++ b/format.go
@@ -492,22 +492,25 @@ func (d *digits) pad(buf []byte, pad int, printSign, padSign, padRight, padZero 
 			buf = append(buf, padChar)
 		}
 	} else {
-		tmp := make([]byte, pad)
+		// Determine where to keep the sign.
 		i := 0
-
 		if padZero && (d.neg || printSign || padSign) {
-			tmp[0] = buf[0]
-			buf = buf[1:]
 			i = 1
 			p++
 		}
 
-		for ; i < p; i++ {
-			tmp[i] = padChar
+		// Grow buf until it fits the nb + padding.
+		for len(buf) < pad {
+			buf = append(buf, 0)
 		}
 
-		copy(tmp[p:], buf)
-		buf = tmp
+		// Move the existing number to the end of the buffer.
+		copy(buf[p:], buf[i:])
+
+		// Fill left-padding chars.
+		for ; i < p; i++ {
+			buf[i] = padChar
+		}
 	}
 
 	return buf

--- a/json.go
+++ b/json.go
@@ -14,7 +14,8 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	digs := d.digits()
+	var digs digits
+	d.digits(&digs)
 
 	prec := 0
 	if digs.ndig != 0 {


### PR DESCRIPTION
Reducing the number of allocations is an important performance improvement, as it reduces the pressure for GC events. This PR is split into various commits to ease reviewing. The first one adds a benchmark against which to compare the improvements, and then each following PR makes incremental changes, in order to make it clear they don't change the semantics for formatting.

Comparison of the benchmarks before/after this set of commits:

```
name                                    old time/op    new time/op    delta
Format/large_number_f_format-4             688ns ± 1%     609ns ± 1%  -11.54%  (p=0.000 n=10+10)
Format/large_number_e_format-4             686ns ± 1%     608ns ± 1%  -11.49%  (p=0.000 n=10+10)
Format/large_number_padding_f_format-4     882ns ± 1%     732ns ± 1%  -17.06%  (p=0.000 n=10+10)
Format/large_number_padding_e_format-4     840ns ± 1%     723ns ± 2%  -13.99%  (p=0.000 n=10+8)
Format/special-4                           130ns ± 2%     118ns ± 3%   -8.85%  (p=0.000 n=10+10)
Format/special_with_padding-4              261ns ± 1%     273ns ±14%     ~     (p=0.079 n=9+10)

name                                    old alloc/op   new alloc/op   delta
Format/large_number_f_format-4              112B ± 0%       24B ± 0%  -78.57%  (p=0.000 n=10+10)
Format/large_number_e_format-4             88.0B ± 0%     16.0B ± 0%  -81.82%  (p=0.000 n=10+10)
Format/large_number_padding_f_format-4      304B ± 0%       80B ± 0%  -73.68%  (p=0.000 n=10+10)
Format/large_number_padding_e_format-4      200B ± 0%       80B ± 0%  -60.00%  (p=0.000 n=10+10)
Format/special-4                           0.00B          0.00B          ~     (all equal)
Format/special_with_padding-4              80.0B ± 0%     80.0B ± 0%     ~     (all equal)

name                                    old allocs/op  new allocs/op  delta
Format/large_number_f_format-4              3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
Format/large_number_e_format-4              3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
Format/large_number_padding_f_format-4      5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.000 n=10+10)
Format/large_number_padding_e_format-4      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)
Format/special-4                            0.00           0.00          ~     (all equal)
Format/special_with_padding-4               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```