### PR TITLE
remove duplication of parse logic in UnmarshalJSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -42,255 +42,42 @@ func (d *Decimal) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	l := len(data)
-
-	if l == 0 {
+	if len(data) == 0 {
 		return nil
 	}
 
-	neg := false
-
-	i := 0
-	if data[0] == '+' {
-		i = 1
-	} else if data[0] == '-' {
-		neg = true
-		i = 1
-	}
-
-	var sig64 uint64
-	var nfrac int16
-	var trunc int8
-	caneof := false
-	cansgn := false
-	eneg := false
-	sawdig := false
-	sawdot := false
-	sawexp := false
-
-	for ; !sawexp && sig64 < 0x18ff_ffff_ffff_ffff && i < l; i++ {
-		switch c := data[i]; true {
-		case c >= '0' && c <= '9':
-			caneof = true
-			cansgn = false
-			sawdig = true
-
-			sig64 = sig64*10 + uint64(c-'0')
-
-			if sawdot {
-				nfrac++
+	// Pass an empty NaN payload because NaN values are not valid in JSON, so we should never
+	// encounter a NaN.
+	dec, err := parse(data, 0)
+	if err != nil {
+		// If there was a parse error, check if the first byte of the input looks like any known JSON values and
+		// return a more informative JSON unmarshal error. Otherwise, return the original parse error.
+		switch data[0] {
+		case 'f', 't':
+			return &json.UnmarshalTypeError{
+				Value: "bool",
+				Type:  reflect.TypeOf(Decimal{}),
 			}
-		case c == '.':
-			if sawdot {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
+		case '"':
+			return &json.UnmarshalTypeError{
+				Value: "string",
+				Type:  reflect.TypeOf(Decimal{}),
 			}
-
-			caneof = true
-			cansgn = false
-			sawdot = true
-		case c == 'E' || c == 'e':
-			if !sawdig {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
+		case '{':
+			return &json.UnmarshalTypeError{
+				Value: "JSON object",
+				Type:  reflect.TypeOf(Decimal{}),
 			}
-
-			caneof = true
-			cansgn = true
-			sawexp = true
+		case '[':
+			return &json.UnmarshalTypeError{
+				Value: "JSON array",
+				Type:  reflect.TypeOf(Decimal{}),
+			}
 		default:
-			err := &json.UnmarshalTypeError{
-				Type: reflect.TypeOf(Decimal{}),
-			}
-
-			switch data[0] {
-			case 'f', 't':
-				err.Value = "bool"
-			case '"':
-				err.Value = "string"
-			default:
-				err.Value = "number " + string(data)
-			}
-
 			return err
 		}
 	}
 
-	sig := uint128{sig64, 0}
-	var exp int16
-	maxexp := false
-
-	for ; i < l; i++ {
-		switch c := data[i]; true {
-		case c >= '0' && c <= '9':
-			caneof = true
-			cansgn = false
-			sawdig = true
-
-			if sawexp {
-				if exp > exponentBias/10+1 {
-					maxexp = true
-				}
-
-				exp *= 10
-				exp += int16(c - '0')
-			} else {
-				if sig[1] <= 0x18ff_ffff_ffff_ffff {
-					if sig[1] <= 0x027f_ffff_ffff_ffff && i < l-1 {
-						c2 := data[i+1]
-						if c2 >= '0' && c2 <= '9' {
-							sig = sig.mul64(100)
-							sig = sig.add64(uint64(c-'0')*10 + uint64(c2-'0'))
-
-							if sawdot {
-								nfrac += 2
-							}
-
-							i++
-							continue
-						}
-					}
-
-					sig = sig.mul64(10)
-					sig = sig.add64(uint64(c - '0'))
-
-					if sawdot {
-						nfrac++
-					}
-				} else {
-					if c != '0' {
-						trunc = 1
-					}
-
-					if !sawdot {
-						if exp < exponentBias+39 {
-							nfrac--
-						}
-					}
-				}
-			}
-		case c == '.':
-			if sawdot || sawexp {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
-			}
-
-			caneof = true
-			cansgn = false
-			sawdot = true
-		case c == 'E' || c == 'e':
-			if !sawdig || sawexp {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
-			}
-
-			caneof = true
-			cansgn = true
-			sawexp = true
-		case c == '-':
-			if !cansgn {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
-			}
-
-			caneof = false
-			cansgn = false
-			eneg = true
-		case c == '+':
-			if !cansgn {
-				return &json.UnmarshalTypeError{
-					Value: "number " + string(data),
-					Type:  reflect.TypeOf(Decimal{}),
-				}
-			}
-
-			caneof = false
-			cansgn = false
-		default:
-			err := &json.UnmarshalTypeError{
-				Type: reflect.TypeOf(Decimal{}),
-			}
-
-			switch data[0] {
-			case 'f', 't':
-				err.Value = "bool"
-			case '"':
-				err.Value = "string"
-			default:
-				err.Value = "number " + string(data)
-			}
-
-			return err
-		}
-	}
-
-	if !caneof {
-		return &json.UnmarshalTypeError{
-			Value: "number " + string(data),
-			Type:  reflect.TypeOf(Decimal{}),
-		}
-	}
-
-	// If the exponent value is larger than the maximum supported exponent,
-	// there are two cases where the value is still valid:
-	//  - the exponent is negative, where the logical value rounds to 0
-	//  - the significand is zero, where the logical value is 0
-	//
-	// Otherwise, return a range error.
-	if maxexp {
-		if eneg {
-			*d = zero(neg)
-			return nil
-		}
-
-		if sig == (uint128{}) {
-			*d = zero(neg)
-			return nil
-		}
-
-		return &json.UnmarshalTypeError{
-			Value: "number " + string(data),
-			Type:  reflect.TypeOf(Decimal{}),
-		}
-	}
-
-	if eneg {
-		exp *= -1
-	}
-
-	exp -= nfrac
-
-	if exp > maxUnbiasedExponent+39 {
-		return &json.UnmarshalTypeError{
-			Value: "number " + string(data),
-			Type:  reflect.TypeOf(Decimal{}),
-		}
-	}
-
-	if exp < minUnbiasedExponent-39 {
-		*d = zero(neg)
-		return nil
-	}
-
-	sig, exp = DefaultRoundingMode.reduce128(neg, sig, exp+exponentBias, trunc)
-
-	if exp > maxBiasedExponent {
-		return &json.UnmarshalTypeError{
-			Value: "number " + string(data),
-			Type:  reflect.TypeOf(Decimal{}),
-		}
-	}
-
-	*d = compose(neg, sig, exp)
+	*d = dec
 	return nil
 }

--- a/json_test.go
+++ b/json_test.go
@@ -78,3 +78,30 @@ func FuzzDecimalUnmarshalJSON(f *testing.F) {
 		_, _ = dec.MarshalJSON()
 	})
 }
+
+func BenchmarkDecimalUnmarshalJSON(b *testing.B) {
+	texts := [][]byte{
+		[]byte("0.00000000000000000000000000000000000005"),
+		[]byte("0.00000000000000000000000000000000000005e30"),
+		[]byte("500000000000000000000000000000000000000e30"),
+		[]byte("0.00000000000000000000000000000000000005e-6150"),
+		[]byte("0.00000000000000000000000000000000000005e-999999"),
+		[]byte("0e99999999"),
+		[]byte("0"),
+		[]byte("+1234567890"),
+		[]byte("00123.45600e10"),
+		[]byte("123.456e-10"),
+	}
+
+	for _, text := range texts {
+		b.Run(string(text), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var res Decimal
+				err := res.UnmarshalJSON(text)
+				if err != nil {
+					b.Errorf("failed to scan %q: %v", text, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Remove the duplicate parse logic in `UnmarshalJSON`; use the `parse` function instead. Add a benchmark for `UnmarshalJSON` to measure change in performance.

Here's the [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) output comparing the old and new `UnmarshalJSON` code (run on a 2021 14" Macbook Pro, M1 Pro):
```
goos: darwin
goarch: arm64
pkg: github.com/woodsbury/decimal128
                                                                        │   old.txt   │               new.txt               │
                                                                        │   sec/op    │   sec/op     vs base                │
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005-8           49.54n ± 0%   50.53n ± 0%   +2.00% (p=0.000 n=10)
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e30-8        51.50n ± 0%   52.20n ± 0%   +1.37% (p=0.000 n=10)
DecimalUnmarshalJSON/500000000000000000000000000000000000000e30-8         129.4n ± 0%   137.1n ± 0%   +5.95% (p=0.000 n=10)
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-6150-8     65.86n ± 0%   66.25n ± 0%   +0.59% (p=0.000 n=10)
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-999999-8   50.09n ± 0%   52.22n ± 0%   +4.25% (p=0.000 n=10)
DecimalUnmarshalJSON/0e99999999-8                                         14.59n ± 0%   16.45n ± 0%  +12.75% (p=0.000 n=10)
DecimalUnmarshalJSON/0-8                                                  15.09n ± 0%   13.31n ± 3%  -11.83% (p=0.000 n=10)
DecimalUnmarshalJSON/+1234567890-8                                        17.69n ± 0%   19.55n ± 0%  +10.54% (p=0.000 n=10)
DecimalUnmarshalJSON/00123.45600e10-8                                     23.72n ± 0%   25.44n ± 0%   +7.23% (p=0.000 n=10)
DecimalUnmarshalJSON/123.456e-10-8                                        23.14n ± 0%   25.12n ± 0%   +8.54% (p=0.000 n=10)
geomean                                                                   34.41n        35.76n        +3.92%

                                                                        │   old.txt    │               new.txt               │
                                                                        │     B/op     │    B/op     vs base                 │
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e30-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/500000000000000000000000000000000000000e30-8         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-6150-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-999999-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0e99999999-8                                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0-8                                                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/+1234567890-8                                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/00123.45600e10-8                                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/123.456e-10-8                                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                              ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                                        │   old.txt    │               new.txt               │
                                                                        │  allocs/op   │ allocs/op   vs base                 │
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005-8           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e30-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/500000000000000000000000000000000000000e30-8         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-6150-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0.00000000000000000000000000000000000005e-999999-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0e99999999-8                                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/0-8                                                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/+1234567890-8                                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/00123.45600e10-8                                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecimalUnmarshalJSON/123.456e-10-8                                        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                              ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```